### PR TITLE
Implement Sensiron SHT4xl temperature and humidity sensor

### DIFF
--- a/lib/sensors/sensiron_sht4lx.ex
+++ b/lib/sensors/sensiron_sht4lx.ex
@@ -1,0 +1,96 @@
+defmodule Sensiron.SHT4xl do
+  @moduledoc """
+  Sensiron SHT4xl relative humidity and temperature sensor
+
+  See:
+    https://www.mouser.com/datasheet/2/682/Sensirion_Humidity_Sensors_SHT4xI_Datasheet-2887008.pdf
+  """
+
+  @i2c_address 0x44
+
+  # Commands
+  @command_serial_number 0x89
+  @soft_reset 0x94
+  @command_measure_low_precision 0xE0
+  @command_measure_medium_precision 0xF6
+  @command_measure_high_precision 0xFD
+
+  @doc """
+  Performs a soft reset of the sensor.
+  """
+  @spec reset(i2c :: Circuits.I2C.bus()) :: :ok | {:error, term()}
+  def reset(i2c) do
+    Circuits.I2C.write(i2c, @i2c_address, <<@soft_reset>>)
+  end
+
+  @doc """
+  Get the sensor's serial number as a base 16 encoded string.
+  """
+  @spec serial_number(i2c :: Circuits.I2C.bus()) :: {:ok, String.t()} | {:error, term}
+  def serial_number(i2c) do
+    with :ok <- Circuits.I2C.write(i2c, @i2c_address, <<@command_serial_number>>),
+         {:ok,
+          <<
+            serial_byte_1::size(8),
+            serial_byte_2::size(8),
+            _checksum_1::size(8),
+            serial_byte_3::size(8),
+            serial_byte_4::size(8),
+            _checksum_2::size(8)
+          >>} <- Circuits.I2C.read(i2c, @i2c_address, 6) do
+      {:ok, Base.encode16(<<serial_byte_1, serial_byte_2, serial_byte_3, serial_byte_4>>)}
+    end
+  end
+
+  @doc """
+  Take a temperature and humidity reading.
+
+  ## Opts
+  - `:units` - Units to return temperature in (`:c` - celsius, `:f` - fahrenheit). Default `:c`.
+  - `:precision` - Duration and repeatability of the measurement (`:low`, `:medium`, `:high`). Default `:low`.
+  """
+  @spec temperature_and_humidity(i2c :: Circuits.I2C.bus(),
+          units: :c | :f,
+          precision: :low | :medium | :high
+        ) ::
+          {:ok, {temperature :: float, humidity :: float}}
+          | {:error, term}
+  def temperature_and_humidity(i2c, opts \\ []) do
+    units = Keyword.get(opts, :units, :c)
+    precision = Keyword.get(opts, :precision, :low)
+
+    {command, wait_time} =
+      case precision do
+        :high -> {@command_measure_high_precision, 10}
+        :medium -> {@command_measure_medium_precision, 5}
+        :low -> {@command_measure_low_precision, 2}
+      end
+
+    with :ok <- Circuits.I2C.write(i2c, @i2c_address, <<command>>),
+         Process.sleep(wait_time),
+         {:ok,
+          <<
+            temperature_word::size(16),
+            _checksum_1::size(8),
+            humidity_word::size(16),
+            _checksum_2::size(8)
+          >>} <- Circuits.I2C.read(i2c, @i2c_address, 6) do
+      humidity = -6 + 125 * humidity_word / 65535
+
+      temperature =
+        case units do
+          :c -> -45 + 175 * temperature_word / 65535
+          :f -> -49 + 315 * temperature_word / 65535
+        end
+
+      humidity =
+        cond do
+          humidity < 0 -> 0
+          humidity > 100 -> 100
+          true -> humidity
+        end
+
+      {:ok, {Float.round(temperature, 2), Float.round(humidity, 2)}}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule NervesSense.MixProject do
       version: "0.1.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       dialyzer: [
         ignore_warnings: "dialyzer.ignore.exs",
@@ -26,11 +27,14 @@ defmodule NervesSense.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:circuits_i2c, "~> 1.1"},
-      {:circuits_uart, "~> 1.5"},
+      {:circuits_i2c, "~> 1.1", only: [:dev, :prod]},
+      {:circuits_uart, "~> 1.5", only: [:dev, :prod]},
       {:dialyxir, "~> 1.2", only: :dev, runtime: false}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Path to the dialyzer .plt file.
   defp plt_file_path do

--- a/test/mocks/circuits_i2c.ex
+++ b/test/mocks/circuits_i2c.ex
@@ -1,0 +1,54 @@
+defmodule Circuits.I2C do
+  @moduledoc false
+
+  use GenServer
+
+  defmodule State do
+    @moduledoc false
+    defstruct [:next_response]
+  end
+
+  def open("i2c-test") do
+    GenServer.start_link(__MODULE__, nil)
+  end
+
+  # Serial number
+  def write(pid, 0x44, <<0x89>>), do: next_response(pid, <<16, 150, 112, 108, 49, 148>>)
+  # Reset
+  def write(pid, 0x44, <<0x94>>), do: next_response(pid, <<>>)
+  # Measure low precision
+  def write(pid, 0x44, <<0xE0>>), do: next_response(pid, <<109, 68, 109, 51, 175, 204>>)
+  # Measure medium precision
+  def write(pid, 0x44, <<0xF6>>), do: next_response(pid, <<109, 70, 15, 51, 186, 122>>)
+  # Measure high precision
+  def write(pid, 0x44, <<0xFD>>), do: next_response(pid, <<109, 62, 78, 52, 26, 40>>)
+
+  def read(pid, 0x44, _length) do
+    GenServer.call(pid, :read)
+  end
+
+  @impl GenServer
+  def init(_) do
+    {:ok, %State{next_response: nil}}
+  end
+
+  @impl GenServer
+  def handle_call({:next_response, data}, _from, state) do
+    {:reply, :ok, %State{state | next_response: data}}
+  end
+
+  @impl GenServer
+  def handle_call(:read, _from, state) do
+    response =
+      case state.next_response do
+        nil -> {:error, :i2c_nak}
+        data -> {:ok, data}
+      end
+
+    {:reply, response, %State{state | next_response: nil}}
+  end
+
+  defp next_response(pid, data) do
+    GenServer.call(pid, {:next_response, data})
+  end
+end

--- a/test/sensiron_sht4lx_test.exs
+++ b/test/sensiron_sht4lx_test.exs
@@ -1,0 +1,29 @@
+defmodule Sensiron.SHT4xl.Test do
+  use ExUnit.Case
+
+  test "reset sensor" do
+    {:ok, i2c} = Circuits.I2C.open("i2c-test")
+    assert Sensiron.SHT4xl.reset(i2c) == :ok
+  end
+
+  test "get serial number" do
+    {:ok, i2c} = Circuits.I2C.open("i2c-test")
+    assert Sensiron.SHT4xl.serial_number(i2c) == {:ok, "10966C31"}
+  end
+
+  test "get temperature and humidity" do
+    {:ok, i2c} = Circuits.I2C.open("i2c-test")
+
+    assert Sensiron.SHT4xl.temperature_and_humidity(i2c) ==
+             {:ok, {29.69, 19.24}}
+
+    assert Sensiron.SHT4xl.temperature_and_humidity(i2c, units: :f) ==
+             {:ok, {85.45, 19.24}}
+
+    assert Sensiron.SHT4xl.temperature_and_humidity(i2c, precision: :medium) ==
+             {:ok, {29.7, 19.26}}
+
+    assert Sensiron.SHT4xl.temperature_and_humidity(i2c, precision: :high) ==
+             {:ok, {29.68, 19.44}}
+  end
+end


### PR DESCRIPTION
This PR implements the [Sensiron temperature/humidity sensor](https://www.mouser.com/datasheet/2/682/Sensirion_Humidity_Sensors_SHT4xI_Datasheet-2887008.pdf). There are heater modes that have been omitted for now because they can damage the sensor if used incorrectly.